### PR TITLE
It's sys.exit not exit

### DIFF
--- a/library/sn3218.py
+++ b/library/sn3218.py
@@ -4,9 +4,9 @@ try:
     from smbus import SMBus
 except ImportError:
     if sys.version_info[0] < 3:
-        exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
+        sys.exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
     elif sys.version_info[0] == 3:
-        exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
+        sys.exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
 
 I2C_ADDRESS = 0x54
 CMD_ENABLE_OUTPUT = 0x00


### PR DESCRIPTION
Fixes this bug when using it without smbus installed:

```
In [5]: from dot3k import backlight
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
/root/.virtualenvs/display/lib/python3.4/site-packages/sn3218.py in <module>()
      3 try:
----> 4     from smbus import SMBus
      5 except ImportError:

ImportError: No module named 'smbus'

During handling of the above exception, another exception occurred:

NameError                                 Traceback (most recent call last)
<ipython-input-5-6713a8a46edb> in <module>()
----> 1 from dot3k import backlight

/root/.virtualenvs/display/lib/python3.4/site-packages/dot3k/backlight.py in <module>()
----> 1 import sn3218, colorsys, math
      2
      3 LED_R_R = 0x00
      4 LED_R_G = 0x01
      5 LED_R_B = 0x02

/root/.virtualenvs/display/lib/python3.4/site-packages/sn3218.py in <module>()
      7         exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
      8     elif sys.version_info[0] == 3:
----> 9         exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
     10
     11 I2C_ADDRESS = 0x54

NameError: name 'exit' is not defined
```
