### PR TITLE
Add output_raw

### DIFF
--- a/library/sn3218.py
+++ b/library/sn3218.py
@@ -24,28 +24,28 @@ def i2c_bus_id():
 
 
 def enable():
-    """ 
+    """
     Enables output.
     """
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_ENABLE_OUTPUT, [0x01])
 
 
 def disable():
-    """ 
+    """
     Disables output.
     """
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_ENABLE_OUTPUT, [0x00])
 
 
 def reset():
-    """ 
+    """
     Resets all internal registers.
     """
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_RESET, [0xFF])
 
 
 def enable_leds(enable_mask):
-    """ 
+    """
     Enables or disables each LED channel. The first 18 bit values are
     used to determine the state of each channel (1=on, 0=off) if fewer
     than 18 bits are provided the remaining channels are turned off.
@@ -58,13 +58,13 @@ def enable_leds(enable_mask):
     if type(enable_mask) is not int:
         raise TypeError("enable_mask must be an integer")
 
-    i2c.write_i2c_block_data(I2C_ADDRESS, CMD_ENABLE_LEDS, 
+    i2c.write_i2c_block_data(I2C_ADDRESS, CMD_ENABLE_LEDS,
                              [enable_mask & 0x3F, (enable_mask >> 6) & 0x3F, (enable_mask >> 12) & 0X3F])
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_UPDATE, [0xFF])
 
 
 def channel_gamma(channel, gamma_table):
-    """ 
+    """
     Overrides the gamma table for a single channel.
 
     Args:
@@ -74,7 +74,7 @@ def channel_gamma(channel, gamma_table):
         TypeError: if channel is not an integer.
         ValueError: if channel is not in the range 0..17.
         TypeError: if gamma_table is not a list.
-    """	
+    """
     global channel_gamma_table
 
     if type(channel) is not int:
@@ -86,18 +86,18 @@ def channel_gamma(channel, gamma_table):
     if type(gamma_table) is not list or len(gamma_table) != 256:
         raise TypeError("gamma_table must be a list of 256 integers")
 
-    channel_gamma_table[channel] = gamma_table	
+    channel_gamma_table[channel] = gamma_table
 
 
 def output(values):
-    """ 
+    """
     Outputs a new set of values to the driver
 
     Args:
         values (list): channel number
     Raises:
         TypeError: if values is not a list.
-    """ 
+    """
     if type(values) is not list or len(values) != 18:
         raise TypeError("values must be a list of 18 integers")
 
@@ -115,14 +115,14 @@ enable_leds(0b111111111111111111)
 
 if __name__ == "__main__":
     print("sn3218 test cycles")
-    
+
     import time
     import math
 
     # enable output
     enable()
     enable_leds(0b111111111111111111)
-    
+
     print(">> test enable mask (on/off)")
     enable_mask = 0b000000000000000000
     output([0x10] * 18)

--- a/library/sn3218.py
+++ b/library/sn3218.py
@@ -55,7 +55,7 @@ def enable_leds(enable_mask):
     Raises:
         TypeError: if enable_mask is not an integer.
     """
-    if type(enable_mask) is not int:
+    if not isinstance(enable_mask, int):
         raise TypeError("enable_mask must be an integer")
 
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_ENABLE_LEDS,
@@ -77,13 +77,13 @@ def channel_gamma(channel, gamma_table):
     """
     global channel_gamma_table
 
-    if type(channel) is not int:
+    if not isinstance(channel, int):
         raise TypeError("channel must be an integer")
 
     if channel not in range(18):
         raise ValueError("channel be an integer in the range 0..17")
 
-    if type(gamma_table) is not list or len(gamma_table) != 256:
+    if not isinstance(gamma_table, list) or len(gamma_table) != 256:
         raise TypeError("gamma_table must be a list of 256 integers")
 
     channel_gamma_table[channel] = gamma_table
@@ -96,9 +96,9 @@ def output(values):
     Args:
         values (list): channel number
     Raises:
-        TypeError: if values is not a list.
+        TypeError: if values is not a list of 18 integers.
     """
-    if type(values) is not list or len(values) != 18:
+    if not isinstance(values, list) or len(values) != 18:
         raise TypeError("values must be a list of 18 integers")
 
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_SET_PWM_VALUES, [channel_gamma_table[i][values[i]] for i in range(18)])
@@ -113,9 +113,10 @@ def output_raw(values):
     Args:
         values (list): channel number
     Raises:
-        TypeError: if values is not a list.
+        TypeError: if values is not a list of 18 integers.
     """
-    if type(values) is not list or len(values) != 18:
+    # SMBus.write_i2c_block_data does the type check, so we don't have to
+    if len(values) != 18:
         raise TypeError("values must be a list of 18 integers")
 
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_SET_PWM_VALUES, values)

--- a/library/sn3218.py
+++ b/library/sn3218.py
@@ -91,7 +91,7 @@ def channel_gamma(channel, gamma_table):
 
 def output(values):
     """
-    Outputs a new set of values to the driver
+    Outputs a new set of values to the driver.
 
     Args:
         values (list): channel number
@@ -102,6 +102,23 @@ def output(values):
         raise TypeError("values must be a list of 18 integers")
 
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_SET_PWM_VALUES, [channel_gamma_table[i][values[i]] for i in range(18)])
+    i2c.write_i2c_block_data(I2C_ADDRESS, CMD_UPDATE, [0xFF])
+
+
+def output_raw(values):
+    """
+    Outputs a new set of values to the driver.
+    Similar to output(), but does not use channel_gamma_table.
+
+    Args:
+        values (list): channel number
+    Raises:
+        TypeError: if values is not a list.
+    """
+    if type(values) is not list or len(values) != 18:
+        raise TypeError("values must be a list of 18 integers")
+
+    i2c.write_i2c_block_data(I2C_ADDRESS, CMD_SET_PWM_VALUES, values)
     i2c.write_i2c_block_data(I2C_ADDRESS, CMD_UPDATE, [0xFF])
 
 


### PR DESCRIPTION
2 reasons:
- There's currently no way to access CMD_SET_PWM_VALUES without gamma adjustment
- Avoiding the 18-channel lookup saves time; output_raw() takes roughly 65% of the time of output() according to some quick-n-dirty profiling